### PR TITLE
I've moved Tag module to Mactag module in order to keep global namespace clean

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mactag (0.3.3)
+    mactag (0.4.0)
       bundler (>= 0.9.26)
       rails (>= 3.0.0.beta1)
 

--- a/lib/mactag/tag.rb
+++ b/lib/mactag/tag.rb
@@ -3,5 +3,7 @@ require 'mactag/tag/plugin'
 require 'mactag/tag/gem'
 require 'mactag/tag/rails'
 
-module Tag
+module Mactag
+  module Tag
+  end
 end

--- a/spec/mactag/tag_spec.rb
+++ b/spec/mactag/tag_spec.rb
@@ -1,0 +1,5 @@
+describe "Tag" do
+  it "does not pollute global namespace" do
+    Object.const_defined?(:Tag).should be_false
+  end 
+end


### PR DESCRIPTION
It caused problems when model named Tag existed in rails application

I've added 2 lines of solution with spec
