### PR TITLE
When the path contains other version numbers extract correct version

### DIFF
--- a/lib/mactag/tag/gem.rb
+++ b/lib/mactag/tag/gem.rb
@@ -58,7 +58,7 @@ module Mactag
             else
               gem = dirs.sort.last
             end
-            if /-(.+)$/.match(gem)
+            if /-([^\/]+)$/.match(gem)
               $1
             end
           end

--- a/spec/mactag/tag/gem_spec.rb
+++ b/spec/mactag/tag/gem_spec.rb
@@ -102,5 +102,16 @@ describe Mactag::Tag::Gem do
         Mactag::Tag::Gem.last('devise').should eq('1.1.1')
       end
     end
+    
+    context 'when the path contains other version numbers' do
+      before do
+        Mactag::Tag::Gem.stub(:dirs) { ['/Users/user/.rvm/gems/ree-1.8.7-2011.03@project/gems/simple_form-1.3.1'] }
+      end
+
+      it 'extract correct version' do
+        Mactag::Tag::Gem.last('simple_form').should eq('1.3.1')
+      end      
+    end
+    
   end
 end


### PR DESCRIPTION
When using bundler you can get pretty long paths to your gems and they also contains version numbers sometimes. 

Ex. /Users/mathias/.rvm/gems/ree-1.8.7-2011.03@myproject/gems/simple_form-1.3.1

Just updated the "last" regexp so it grabs the last part and not "1.8.7-2011.03@myproject/gems/simple_form-1.3.1"

Cheers!
