### PR TITLE
Make the mactag command Ruby 1.9.2 compatible

### DIFF
--- a/bin/mactag
+++ b/bin/mactag
@@ -79,7 +79,7 @@ CONFIG
       end
 
       begin
-        require config_file
+        require File.expand_path(File.join(ENV['PWD'], config_file))
 
         Mactag::Builder.create
       rescue Mactag::MactagError => e


### PR DESCRIPTION
In Ruby 1.9.2 `.` is no longer part of the `LOAD_PATH` so requiring a Ruby
file by a relative path needs `require_relative` or a more complex
construct like this one if it should also work in Ruby 1.8.
